### PR TITLE
Better accessibility for the list of call sessions

### DIFF
--- a/blink/sessions.py
+++ b/blink/sessions.py
@@ -2285,7 +2285,12 @@ class AudioSessionModel(QAbstractListModel):
         if role == Qt.UserRole:
             return item
         elif role == Qt.DisplayRole:
-            return unicode(item)
+            props=[]
+            for prop in (item.name, item.status, item.type, item.codec_info, item.duration):
+                if (prop is not None and len(unicode(prop))>0):
+                    props.append(unicode(prop))
+            if (len(props)>=1):
+                return ", ".join(props)
         return None
 
     def supportedDropActions(self):


### PR DESCRIPTION
Issue
When visually disabled user uses Blink with a screen reader such as NVDA on Windows or Orca on Linux, list of sessions presents over verbose non relevant text where the text of an item is expected.
Steps to reproduce:
* Make sure prior to launching Blink, platform specific screen reading app of your choice is already running
* Launch blink with a SIP account configured or at least 1 bonjour peer near by.
* Start an audio call to a contact of your choice.
* As the main window switches into calls view, repeatedly press the tab key until list of active sessions becomes focused.

Current status
The screen reader reports that the list consisting of 1 item has gained the system focus, however it also reports string similar to the following where the text of the list item is expected
  <blink.sessions.AudioSessionItem object at 0x7f8444259350>

Expected status
Blink should provide descriptive text reflecting the real call status corresponding with the list item in question.

Notes
I'm pretty sure experienced accessibility engineers would be able to verify this behaviour by using testing tools such as accprobe or accerciser. Since I my-self am hit by this issue describing real life situation as presented to me by my choice of screen readers is natural for me.

Solution
This pull request fixes the issue for me.
