### PR TITLE
Show both Name and URI in Call History

### DIFF
--- a/blink/history.py
+++ b/blink/history.py
@@ -149,7 +149,7 @@ class HistoryEntry(object):
 
     @property
     def text(self):
-        result = unicode(self.name or self.uri)
+        result = unicode(self.name) + ' ' + '(' + unicode(self.uri) + ')'
         if self.call_time:
             call_time = self.call_time.astimezone(tzlocal())
             call_date = call_time.date()


### PR DESCRIPTION
When a call is placed to a SIP group, sometimes the SIP server sends the group name as Display Name, and thus the soft-phone user cannot identify who they were called by before calling back. 

This works around that by also showing the SIP URI in the recent history.