### PR TITLE
Configuration setting to silence all call alerts

### DIFF
--- a/blink/configuration/settings.py
+++ b/blink/configuration/settings.py
@@ -38,6 +38,7 @@ class AudioSettingsExtension(AudioSettings):
     recordings_directory = Setting(type=ApplicationDataPath, default=ApplicationDataPath('recordings'))
     sample_rate = Setting(type=SampleRate, default=41000 if sys.platform != 'darwin' else 32000)
     echo_canceller = EchoCancellerSettingsExtension
+    play_call_alerts = Setting(type=bool, default=False)
 
 
 class SIPSettingsExtension(SIPSettings):

--- a/blink/preferences.py
+++ b/blink/preferences.py
@@ -304,6 +304,7 @@ class PreferencesWindow(base_class, ui_class, metaclass=QSingleton):
         self.audio_output_device_button.activated[int].connect(self._SH_AudioOutputDeviceButtonActivated)
         self.audio_sample_rate_button.activated[int].connect(self._SH_AudioSampleRateButtonActivated)
         self.enable_echo_cancelling_button.clicked.connect(self._SH_EnableEchoCancellingButtonClicked)
+        self.enable_play_call_alerts_button.clicked.connect(self._SH_EnablePlayCallAlertsButtonClicked)
         self.tail_length_slider.valueChanged.connect(self._SH_TailLengthSliderValueChanged)
 
         # Audio codecs
@@ -712,6 +713,7 @@ class PreferencesWindow(base_class, ui_class, metaclass=QSingleton):
         # Audio devices
         self.load_audio_devices()
         self.enable_echo_cancelling_button.setChecked(settings.audio.echo_canceller.enabled)
+        self.enable_play_call_alerts_button.setChecked(settings.audio.play_call_alerts)
         with blocked_qt_signals(self.tail_length_slider):
             self.tail_length_slider.setValue(settings.audio.echo_canceller.tail_length)
         self.audio_sample_rate_button.clear()
@@ -1611,6 +1613,11 @@ class PreferencesWindow(base_class, ui_class, metaclass=QSingleton):
     def _SH_TailLengthSliderValueChanged(self, value):
         settings = SIPSimpleSettings()
         settings.audio.echo_canceller.tail_length = value
+        settings.save()
+
+    def _SH_EnablePlayCallAlertsButtonClicked(self, checked):
+        settings = SIPSimpleSettings()
+        settings.audio.play_call_alerts = checked
         settings.save()
 
     # Audio codecs signal handlers

--- a/resources/preferences.ui
+++ b/resources/preferences.ui
@@ -2041,7 +2041,14 @@
              </property>
             </widget>
            </item>
-           <item row="5" column="0">
+           <item row="5" column="1" colspan="2">
+            <widget class="QCheckBox" name="enable_play_call_alerts_button">
+             <property name="text">
+              <string>Play call alerts</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0">
             <widget class="QLabel" name="tail_length_label">
              <property name="text">
               <string>Tail Length:</string>


### PR DESCRIPTION
I use blink-qt in a broadcasting context, and require all alerts to be silenced when blink-qt is connected to a mixing desk. I thought I'd contribute my change upstream.

As well, if you could provide any feedback as to whether I'm doing this correctly, that was be great!

Cheers and thanks!

David