### PR TITLE
Fix decode error when handling unencrypted messages

### DIFF
--- a/blink/chatwindow.py
+++ b/blink/chatwindow.py
@@ -3641,7 +3641,10 @@ class ChatWindow(base_class, ui_class, ColorHelperMixin):
         else:
             return
 
-        uri = '%s@%s' % (message.sender.uri.user.decode(), message.sender.uri.host.decode())
+        try:
+            uri = '%s@%s' % (message.sender.uri.user.decode(), message.sender.uri.host.decode())
+        except AttributeError:
+            uri = '%s@%s' % (message.sender.uri.user, message.sender.uri.host)
         account_manager = AccountManager()
         if account_manager.has_account(uri):
             account = account_manager.get_account(uri)


### PR DESCRIPTION
Fix the following exception in blink/chatwindow.py:

```
Exception occurred while calling function handle_notification in the GUI thread Traceback (most recent call last):
File "/usr/lib/python3/dist-packages/blink/__init__.py", line 245, in _EH_CallFunctionEvent
    event.function(*event.args, **event.kw)
  File "/usr/lib/python3/dist-packages/blink/chatwindow.py", line 2866, in handle_notification
    handler(notification)
  File "/usr/lib/python3/dist-packages/blink/chatwindow.py", line 3646, in _NH_ChatStreamGotMessage
    uri = '%s@%s' % (message.sender.uri.user.decode(), message.sender.uri.host.decode())
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'decode'
```