### PR TITLE
set desktopFileName for correct Wayland app_id mapping

### DIFF
--- a/blink/__init__.py
+++ b/blink/__init__.py
@@ -131,6 +131,7 @@ class Blink(QApplication, metaclass=QSingleton):
         self.setOrganizationName("AG Projects")
         self.setApplicationName("Blink")
         self.setApplicationVersion(__version__)
+        self.setDesktopFileName("blink")
         self.setWindowIcon(QIcon(Resources.get('icons/blink.png')))
 
         self.main_window = MainWindow()


### PR DESCRIPTION
currently, Blink defaults to a generic id (com.ag-projects.python3) causing a fallback to a generic system icon in Gnome. calling setDesktopFileName ensures the surface app_id aligns with blink.desktop